### PR TITLE
Improve PrintableRuneWidth performance.

### DIFF
--- a/ansi/buffer.go
+++ b/ansi/buffer.go
@@ -30,7 +30,7 @@ func PrintableRuneWidth(s string) int {
 				ansi = false
 			}
 		} else {
-			n += runewidth.StringWidth(string(c))
+			n += runewidth.RuneWidth(c)
 		}
 	}
 

--- a/ansi/buffer_test.go
+++ b/ansi/buffer_test.go
@@ -15,7 +15,8 @@ func TestBuffer_PrintableRuneWidth(t *testing.T) {
 	}
 }
 
-func BenchmarkPrintableRuneWidth(b *testing.B) {
+// go test -bench=Benchmark_PrintableRuneWidth -benchmem -count=4
+func Benchmark_PrintableRuneWidth(b *testing.B) {
 	s := "\x1B[38;2;249;38;114mfoo"
 	var n int
 


### PR DESCRIPTION
OLD:
```hs
Benchmark_PrintableRuneWidth-8           4717250               255 ns/op               0 B/op          0 allocs/op
Benchmark_PrintableRuneWidth-8           4819238               257 ns/op               0 B/op          0 allocs/op
Benchmark_PrintableRuneWidth-8           4755002               257 ns/op               0 B/op          0 allocs/op
Benchmark_PrintableRuneWidth-8           4683806               255 ns/op               0 B/op          0 allocs/op
```

NEW:
```hs
Benchmark_PrintableRuneWidth-8           6802281               177 ns/op               0 B/op          0 allocs/op
Benchmark_PrintableRuneWidth-8           7094738               176 ns/op               0 B/op          0 allocs/op
Benchmark_PrintableRuneWidth-8           6692834               177 ns/op               0 B/op          0 allocs/op
Benchmark_PrintableRuneWidth-8           6692290               177 ns/op               0 B/op          0 allocs/op
```