### PR TITLE
Improve ansi Writer's Write performance.

### DIFF
--- a/ansi/writer.go
+++ b/ansi/writer.go
@@ -1,46 +1,46 @@
 package ansi
 
 import (
+	"bytes"
 	"io"
-	"strings"
 )
 
 type Writer struct {
 	Forward io.Writer
 
 	ansi       bool
-	ansiseq    string
-	lastseq    string
+	ansiseq    bytes.Buffer
+	lastseq    bytes.Buffer
 	seqchanged bool
 }
 
 // Write is used to write content to the ANSI buffer.
 func (w *Writer) Write(b []byte) (int, error) {
-	for _, c := range string(b) {
+	for i, c := range b {
 		if c == '\x1B' {
 			// ANSI escape sequence
 			w.ansi = true
 			w.seqchanged = true
-			w.ansiseq += string(c)
+			_ = w.ansiseq.WriteByte(c)
 		} else if w.ansi {
-			w.ansiseq += string(c)
+			_ = w.ansiseq.WriteByte(c)
 			if (c >= 0x41 && c <= 0x5a) || (c >= 0x61 && c <= 0x7a) {
 				// ANSI sequence terminated
 				w.ansi = false
 
-				_, _ = w.Forward.Write([]byte(w.ansiseq))
-				if strings.HasSuffix(w.ansiseq, "[0m") {
+				if bytes.HasSuffix(w.ansiseq.Bytes(), []byte("[0m")) {
 					// reset sequence
-					w.lastseq = ""
+					w.lastseq.Reset()
 					w.seqchanged = false
-				} else if strings.HasSuffix(w.ansiseq, "m") {
+				} else if c == 'm' {
 					// color code
-					w.lastseq = w.ansiseq
+					_, _ = w.lastseq.Write(w.ansiseq.Bytes())
 				}
-				w.ansiseq = ""
+
+				_, _ = w.ansiseq.WriteTo(w.Forward)
 			}
 		} else {
-			_, err := w.Forward.Write([]byte(string(c)))
+			_, err := w.Forward.Write(b[i : i+1])
 			if err != nil {
 				return 0, err
 			}
@@ -51,7 +51,7 @@ func (w *Writer) Write(b []byte) (int, error) {
 }
 
 func (w *Writer) LastSequence() string {
-	return w.lastseq
+	return w.lastseq.String()
 }
 
 func (w *Writer) ResetAnsi() {
@@ -62,5 +62,5 @@ func (w *Writer) ResetAnsi() {
 }
 
 func (w *Writer) RestoreAnsi() {
-	_, _ = w.Forward.Write([]byte(w.lastseq))
+	_, _ = w.Forward.Write(w.lastseq.Bytes())
 }

--- a/ansi/writer_test.go
+++ b/ansi/writer_test.go
@@ -53,8 +53,9 @@ func TestWriter_Write_Error(t *testing.T) {
 	}
 }
 
+// go test -bench=BenchmarkWriter_Write -benchmem -count=4
 func BenchmarkWriter_Write(b *testing.B) {
-	buf := []byte("\x1B[38;2;249;38;114mfoo\x1B[0m")
+	buf := []byte("\x1B[38;2;249;38;114m你好reflow\x1B[0m")
 	w := &Writer{Forward: ioutil.Discard}
 	var (
 		n   int
@@ -80,14 +81,21 @@ func BenchmarkWriter_Write(b *testing.B) {
 	}
 }
 
+func TestWriter_LastSequence(t *testing.T) {
+	w := &Writer{}
+	if s := w.LastSequence(); s != "" {
+		t.Fatalf("LastSequence should be empty, but got %s", s)
+	}
+}
+
 func TestWriter_ResetAnsi(t *testing.T) {
 	b := &bytes.Buffer{}
 	w := &Writer{Forward: b}
 
 	w.ResetAnsi()
 
-	if b.String() != "" {
-		t.Fatal("b should be empty")
+	if s := b.String(); s != "" {
+		t.Fatalf("b should be empty, but got %s", s)
 	}
 
 	w.seqchanged = true
@@ -101,7 +109,10 @@ func TestWriter_ResetAnsi(t *testing.T) {
 
 func TestWriter_RestoreAnsi(t *testing.T) {
 	b := &bytes.Buffer{}
-	w := &Writer{Forward: b, lastseq: "\x1B[38;2;249;38;114m"}
+
+	lastseq := bytes.Buffer{}
+	lastseq.WriteString("\x1B[38;2;249;38;114m")
+	w := &Writer{Forward: b, lastseq: lastseq}
 
 	w.RestoreAnsi()
 


### PR DESCRIPTION
OLD:
```hs
BenchmarkWriter_Write-8           682036              1545 ns/op             320 B/op         25 allocs/op
BenchmarkWriter_Write-8           789792              1521 ns/op             320 B/op         25 allocs/op
BenchmarkWriter_Write-8           725499              1547 ns/op             320 B/op         25 allocs/op
BenchmarkWriter_Write-8           765880              1542 ns/op             320 B/op         25 allocs/op
```

NEW:
```hs
BenchmarkWriter_Write-8          4759159               247 ns/op               0 B/op          0 allocs/op
BenchmarkWriter_Write-8          4847602               254 ns/op               0 B/op          0 allocs/op
BenchmarkWriter_Write-8          5125417               244 ns/op               0 B/op          0 allocs/op
BenchmarkWriter_Write-8          4870538               245 ns/op               0 B/op          0 allocs/op
```