### PR TITLE
Improve dedent performance.

### DIFF
--- a/dedent/dedent.go
+++ b/dedent/dedent.go
@@ -23,7 +23,7 @@ func minIndent(s string) int {
 	)
 	for i := 0; i < len(s); i++ {
 		switch s[i] {
-		case ' ':
+		case ' ', '\t':
 			if shouldAppend {
 				curIndent++
 			}
@@ -51,7 +51,7 @@ func dedent(s string, indent int) string {
 
 	for i := 0; i < len(s); i++ {
 		switch s[i] {
-		case ' ':
+		case ' ', '\t':
 			if shouldOmit {
 				if omitted < indent {
 					omitted++

--- a/dedent/dedent.go
+++ b/dedent/dedent.go
@@ -1,34 +1,73 @@
 package dedent
 
 import (
-	"strings"
+	"bytes"
 )
 
 // String automatically detects the maximum indentation shared by all lines and
 // trims them accordingly.
 func String(s string) string {
-	lines := strings.Split(s, "\n")
-	minIndent := -1
-
-	for _, l := range lines {
-		if len(l) == 0 {
-			continue
-		}
-
-		indent := len(l) - len(strings.TrimLeft(l, " "))
-		if minIndent == -1 || indent < minIndent {
-			minIndent = indent
-		}
-	}
-
-	if minIndent <= 0 {
+	indent := minIndent(s)
+	if indent == 0 {
 		return s
 	}
 
-	var buf strings.Builder
-	for _, l := range lines {
-		l = strings.TrimPrefix(l, strings.Repeat(" ", minIndent))
-		buf.WriteString(l + "\n")
+	return dedent(s, indent)
+}
+
+func minIndent(s string) int {
+	var (
+		curIndent    int
+		minIndent    int
+		shouldAppend = true
+	)
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case ' ':
+			if shouldAppend {
+				curIndent++
+			}
+		case '\n':
+			curIndent = 0
+			shouldAppend = true
+		default:
+			if curIndent > 0 && (minIndent == 0 || curIndent < minIndent) {
+				minIndent = curIndent
+				curIndent = 0
+			}
+			shouldAppend = false
+		}
 	}
-	return strings.TrimSuffix(buf.String(), "\n")
+
+	return minIndent
+}
+
+func dedent(s string, indent int) string {
+	var (
+		omitted    int
+		shouldOmit = true
+		buf        bytes.Buffer
+	)
+
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case ' ':
+			if shouldOmit {
+				if omitted < indent {
+					omitted++
+					continue
+				}
+				shouldOmit = false
+			}
+			buf.WriteByte(s[i])
+		case '\n':
+			omitted = 0
+			shouldOmit = true
+			buf.WriteByte(s[i])
+		default:
+			buf.WriteByte(s[i])
+		}
+	}
+
+	return buf.String()
 }

--- a/dedent/dedent.go
+++ b/dedent/dedent.go
@@ -59,13 +59,13 @@ func dedent(s string, indent int) string {
 				}
 				shouldOmit = false
 			}
-			buf.WriteByte(s[i])
+			_ = buf.WriteByte(s[i])
 		case '\n':
 			omitted = 0
 			shouldOmit = true
-			buf.WriteByte(s[i])
+			_ = buf.WriteByte(s[i])
 		default:
-			buf.WriteByte(s[i])
+			_ = buf.WriteByte(s[i])
 		}
 	}
 

--- a/dedent/dedent_test.go
+++ b/dedent/dedent_test.go
@@ -26,6 +26,14 @@ func TestDedent(t *testing.T) {
 			Expected: "line 1\nline 2\nline 3\n\n",
 		},
 		{
+			Input:    " \tline 1\n\t\tline 2\n\t line 3\n\n",
+			Expected: "line 1\nline 2\nline 3\n\n",
+		},
+		{
+			Input:    "\t\tline 1\n\n\t\tline 2\n\tline 3",
+			Expected: "\tline 1\n\n\tline 2\nline 3",
+		},
+		{
 			Input:    "\n\n\n\n\n\n",
 			Expected: "\n\n\n\n\n\n",
 		},

--- a/dedent/dedent_test.go
+++ b/dedent/dedent_test.go
@@ -42,3 +42,15 @@ func TestDedent(t *testing.T) {
 		}
 	}
 }
+
+// go test -bench=BenchmarkDedent -benchmem -count=4
+func BenchmarkDedent(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		input := "  line 1\n\n  line 2\n line 3"
+		b.ReportAllocs()
+		b.ResetTimer()
+		for pb.Next() {
+			String(input)
+		}
+	})
+}


### PR DESCRIPTION
Hey @muesli I improved dedent package performance by reimplement the logic. Shown as below.

OLD:
```hs
BenchmarkDedent-8        4960327               239 ns/op             224 B/op         10 allocs/op
BenchmarkDedent-8        4607145               242 ns/op             223 B/op         10 allocs/op
BenchmarkDedent-8        5079397               244 ns/op             224 B/op         10 allocs/op
BenchmarkDedent-8        4887057               240 ns/op             223 B/op         10 allocs/op
```

NEW:
```hs
BenchmarkDedent-8       13918354                82.9 ns/op            95 B/op          1 allocs/op
BenchmarkDedent-8       13222630                86.4 ns/op            96 B/op          1 allocs/op
BenchmarkDedent-8       13272577                87.4 ns/op            95 B/op          1 allocs/op
BenchmarkDedent-8       14463898                86.5 ns/op            95 B/op          1 allocs/op
```

But the code is little bit less intuitive than the old one. So feel free to ignore this PR.