### PR TITLE
Add a new method `Flush` to reuse writer

### DIFF
--- a/padding/padding.go
+++ b/padding/padding.go
@@ -123,7 +123,7 @@ func (w *Writer) pad() error {
 }
 
 // Close will finish the padding operation and then closes the writer.
-// Notice that the writer will never be wrote again after it closed.
+// Notice that the writer can never be written to again once it has been closed.
 func (w *Writer) Close() (err error) {
 	if w.closed {
 		return ErrClosed

--- a/padding/padding.go
+++ b/padding/padding.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ErrClosed indicates an error when closing a closed writer
-var ErrClosed = errors.New("padding: close a closed writer")
+var ErrClosed = errors.New("padding: the writer is closed")
 
 type PaddingFunc func(w io.Writer)
 

--- a/padding/padding_test.go
+++ b/padding/padding_test.go
@@ -88,10 +88,6 @@ func TestPaddingWriter(t *testing.T) {
 	if f.String() != exp {
 		t.Errorf("expected:\n\n`%s`\n\nActual Output:\n\n`%s`", exp, f.String())
 	}
-
-	if _, err := f.Write([]byte("bar")); err != ErrClosed {
-		t.Error(err)
-	}
 }
 
 func TestPaddingString(t *testing.T) {
@@ -151,12 +147,6 @@ func TestWriter_pad(t *testing.T) {
 	if actual != expected {
 		t.Errorf("expected:\n\n`%s`\n\nActual Output:\n\n`%s`", expected, actual)
 	}
-
-	f.closed = true
-
-	if err := f.pad(); err != ErrClosed {
-		t.Error(err)
-	}
 }
 
 func TestWriter_Flush(t *testing.T) {
@@ -202,12 +192,6 @@ func TestWriter_Close(t *testing.T) {
 	}
 
 	if err := f.Close(); err != fakeErr {
-		t.Error(err)
-	}
-
-	f.closed = true
-
-	if err := f.Close(); err != ErrClosed {
 		t.Error(err)
 	}
 }

--- a/padding/padding_test.go
+++ b/padding/padding_test.go
@@ -56,7 +56,10 @@ func TestPadding(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		f.Close()
+
+		if err := f.Close(); err != nil {
+			t.Error(err)
+		}
 
 		if f.String() != tc.Expected {
 			t.Errorf("Test %d, expected:\n\n`%s`\n\nActual Output:\n\n`%s`", i, tc.Expected, f.String())
@@ -77,11 +80,17 @@ func TestPaddingWriter(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	f.Close()
+	if err := f.Close(); err != nil {
+		t.Error(err)
+	}
 
 	exp := "foo   \nbar   "
 	if f.String() != exp {
 		t.Errorf("expected:\n\n`%s`\n\nActual Output:\n\n`%s`", exp, f.String())
+	}
+
+	if _, err := f.Write([]byte("bar")); err != ErrClosed {
+		t.Error(err)
 	}
 }
 
@@ -114,7 +123,9 @@ func TestNewWriterPipe(t *testing.T) {
 	if _, err := f.Write([]byte("foobar")); err != nil {
 		t.Error(err)
 	}
-	f.Close()
+	if err := f.Close(); err != nil {
+		t.Error(err)
+	}
 
 	actual := b.String()
 	expected := "foobar    "
@@ -139,6 +150,65 @@ func TestWriter_pad(t *testing.T) {
 	expected := "...."
 	if actual != expected {
 		t.Errorf("expected:\n\n`%s`\n\nActual Output:\n\n`%s`", expected, actual)
+	}
+
+	f.closed = true
+
+	if err := f.pad(); err != ErrClosed {
+		t.Error(err)
+	}
+}
+
+func TestWriter_Flush(t *testing.T) {
+	t.Parallel()
+
+	f := NewWriter(6, nil)
+
+	_, err := f.Write([]byte("foo"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	if err := f.Flush(); err != nil {
+		t.Error(err)
+	}
+
+	exp := "foo   "
+	if f.String() != exp {
+		t.Errorf("expected:\n\n`%s`\n\nActual Output:\n\n`%s`", exp, f.String())
+	}
+
+	_, err = f.Write([]byte("bar"))
+	if err != nil {
+		t.Error(err)
+	}
+	if err := f.Flush(); err != nil {
+		t.Error(err)
+	}
+
+	exp = "bar   "
+	if f.String() != exp {
+		t.Errorf("expected:\n\n`%s`\n\nActual Output:\n\n`%s`", exp, f.String())
+	}
+}
+
+func TestWriter_Close(t *testing.T) {
+	t.Parallel()
+
+	f := &Writer{
+		Padding:    6,
+		lineLen:    1,
+		ansiWriter: &ansi.Writer{Forward: fakeWriter{}},
+	}
+
+	if err := f.Close(); err != fakeErr {
+		t.Error(err)
+	}
+
+	f.closed = true
+
+	if err := f.Close(); err != ErrClosed {
+		t.Error(err)
 	}
 }
 


### PR DESCRIPTION
This PR add a new method `Flush` to reuse writer. Here is the code snippet

```go
package main

import (
	"fmt"
	"io"

	"github.com/muesli/reflow/padding"
)

func main() {
	f := padding.NewWriter(6, func(w io.Writer) {
		_, _ = w.Write([]byte("."))
	})
	f.Write([]byte("foo\nbar"))
	f.Flush()
	// foo...\nbar...
	fmt.Println(f.String())

	f.Write([]byte("bar\nbaz"))
	f.Flush()
	// bar...\nbaz...
	fmt.Println(f.String())
}
```

Further more, when writer closed, it shouldn't be used again according to #13([comment](https://github.com/muesli/reflow/issues/13#issuecomment-712567150)).

Btw I'm not sure the descriptions about `Flush` and `Close` conform to your standard. So if you any ideas, please let me know.