### PR TITLE
Improve ansi buffer PrintableRuneWidth performance

### DIFF
--- a/ansi/buffer.go
+++ b/ansi/buffer.go
@@ -2,6 +2,7 @@ package ansi
 
 import (
 	"bytes"
+	"unsafe"
 
 	"github.com/mattn/go-runewidth"
 )
@@ -13,7 +14,7 @@ type Buffer struct {
 
 // PrintableRuneWidth returns the width of all printable runes in the buffer.
 func (w Buffer) PrintableRuneWidth() int {
-	return PrintableRuneWidth(w.String())
+	return PrintableRuneWidth(b2s(w.Bytes()))
 }
 
 func PrintableRuneWidth(s string) int {
@@ -35,4 +36,14 @@ func PrintableRuneWidth(s string) int {
 	}
 
 	return n
+}
+
+// b2s converts byte slice to a string without memory allocation.
+// See https://groups.google.com/forum/#!msg/Golang-Nuts/ENgbUzYvCuU/90yGx7GUAgAJ .
+//
+// Note it may break if string and/or slice header will change
+// in the future go versions.
+func b2s(b []byte) string {
+	/* #nosec G103 */
+	return *(*string)(unsafe.Pointer(&b))
 }

--- a/ansi/buffer_test.go
+++ b/ansi/buffer_test.go
@@ -17,6 +17,19 @@ func TestBuffer_PrintableRuneWidth(t *testing.T) {
 	}
 }
 
+// go test -bench=BenchmarkBuffer_PrintableRuneWidth -benchmem -count=4
+func BenchmarkBuffer_PrintableRuneWidth(b *testing.B) {
+	var buf Buffer
+	buf.Buffer.WriteString("\x1B[38;2;249;38;114m(\x1B[0m\x1B[38;2;248;248;242mjust another test\x1B[38;2;249;38;114m)\x1B[0m")
+	b.RunParallel(func(pb *testing.PB) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for pb.Next() {
+			buf.PrintableRuneWidth()
+		}
+	})
+}
+
 // go test -bench=Benchmark_PrintableRuneWidth -benchmem -count=4
 func Benchmark_PrintableRuneWidth(b *testing.B) {
 	s := "\x1B[38;2;249;38;114mfoo"


### PR DESCRIPTION
Hey @muesli !

In this improvement, I use `unsafe` to convert byte slice to a string without memory allocation which is heavily used by [fasthttp](https://github.com/valyala/fasthttp/blob/master/bytesconv.go#L328-L351).

OLD:
```hs
BenchmarkBuffer_PrintableRuneWidth-8   	 4995201	       241 ns/op	      95 B/op	       0 allocs/op
BenchmarkBuffer_PrintableRuneWidth-8   	 4939071	       243 ns/op	      96 B/op	       1 allocs/op
BenchmarkBuffer_PrintableRuneWidth-8   	 4903446	       246 ns/op	      95 B/op	       0 allocs/op
BenchmarkBuffer_PrintableRuneWidth-8   	 5072530	       240 ns/op	      95 B/op	       0 allocs/op
BenchmarkBuffer_PrintableRuneWidth-8   	 4879065	       244 ns/op	      95 B/op	       0 allocs/op
BenchmarkBuffer_PrintableRuneWidth-8   	 5018516	       240 ns/op	      96 B/op	       1 allocs/op
BenchmarkBuffer_PrintableRuneWidth-8   	 4881970	       245 ns/op	      95 B/op	       0 allocs/op
BenchmarkBuffer_PrintableRuneWidth-8   	 5002642	       244 ns/op	      95 B/op	       1 allocs/op
BenchmarkBuffer_PrintableRuneWidth-8   	 4909580	       244 ns/op	      95 B/op	       0 allocs/op
BenchmarkBuffer_PrintableRuneWidth-8   	 4891392	       243 ns/op	      96 B/op	       1 allocs/op
```

NEW:
```hs
BenchmarkBuffer_PrintableRuneWidth-8   	 5765908	       203 ns/op	       0 B/op	       0 allocs/op
BenchmarkBuffer_PrintableRuneWidth-8   	 5739984	       204 ns/op	       0 B/op	       0 allocs/op
BenchmarkBuffer_PrintableRuneWidth-8   	 5854398	       204 ns/op	       0 B/op	       0 allocs/op
BenchmarkBuffer_PrintableRuneWidth-8   	 5838634	       203 ns/op	       0 B/op	       0 allocs/op
BenchmarkBuffer_PrintableRuneWidth-8   	 5804761	       202 ns/op	       0 B/op	       0 allocs/op
BenchmarkBuffer_PrintableRuneWidth-8   	 5797371	       203 ns/op	       0 B/op	       0 allocs/op
BenchmarkBuffer_PrintableRuneWidth-8   	 5743213	       203 ns/op	       0 B/op	       0 allocs/op
BenchmarkBuffer_PrintableRuneWidth-8   	 6095284	       203 ns/op	       0 B/op	       0 allocs/op
BenchmarkBuffer_PrintableRuneWidth-8   	 5844835	       207 ns/op	       0 B/op	       0 allocs/op
BenchmarkBuffer_PrintableRuneWidth-8   	 5756268	       209 ns/op	       0 B/op	       0 allocs/op
```

Benchstat:
```hs
name                         old time/op    new time/op    delta
Buffer_PrintableRuneWidth-8     243ns ± 1%     203ns ± 1%   -16.41%  (p=0.000 n=10+8)

name                         old alloc/op   new alloc/op   delta
Buffer_PrintableRuneWidth-8     95.3B ± 1%      0.0B       -100.00%  (p=0.000 n=10+10)

name                         old allocs/op  new allocs/op  delta
Buffer_PrintableRuneWidth-8     0.40 ±150%      0.00           ~     (p=0.087 n=10+10)
```

**I don’t know if you mind this trick of using unsafe, so feel free to close this PR directly.**