### PR TITLE
Improve padding performance

### DIFF
--- a/padding/padding_test.go
+++ b/padding/padding_test.go
@@ -100,6 +100,7 @@ func TestPaddingString(t *testing.T) {
 	}
 }
 
+// go test -bench=BenchmarkPaddingString -benchmem -count=4
 func BenchmarkPaddingString(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		b.ReportAllocs()


### PR DESCRIPTION
Hey @muesli It's me again.

In this PR, I improve padding performance by reusing memory and decreasing memory allocation.

OLD:
```hs
BenchmarkPaddingString-8   	 3406558	       377 ns/op	     431 B/op	      11 allocs/op
BenchmarkPaddingString-8   	 3427154	       355 ns/op	     431 B/op	      11 allocs/op
BenchmarkPaddingString-8   	 3390284	       355 ns/op	     431 B/op	      11 allocs/op
BenchmarkPaddingString-8   	 3398672	       377 ns/op	     430 B/op	      11 allocs/op
BenchmarkPaddingString-8   	 3357385	       358 ns/op	     432 B/op	      11 allocs/op
BenchmarkPaddingString-8   	 3363268	       357 ns/op	     431 B/op	      11 allocs/op
BenchmarkPaddingString-8   	 3323472	       360 ns/op	     431 B/op	      11 allocs/op
BenchmarkPaddingString-8   	 3346086	       362 ns/op	     432 B/op	      11 allocs/op
BenchmarkPaddingString-8   	 3102219	       385 ns/op	     431 B/op	      11 allocs/op
BenchmarkPaddingString-8   	 3270400	       368 ns/op	     431 B/op	      11 allocs/op
```

NEW:
```hs
BenchmarkPaddingString-8   	 7100839	       178 ns/op	      27 B/op	       6 allocs/op
BenchmarkPaddingString-8   	 7155668	       168 ns/op	      28 B/op	       6 allocs/op
BenchmarkPaddingString-8   	 7153846	       169 ns/op	      28 B/op	       6 allocs/op
BenchmarkPaddingString-8   	 7020405	       170 ns/op	      27 B/op	       6 allocs/op
BenchmarkPaddingString-8   	 6902462	       172 ns/op	      27 B/op	       6 allocs/op
BenchmarkPaddingString-8   	 7066556	       183 ns/op	      27 B/op	       6 allocs/op
BenchmarkPaddingString-8   	 6789829	       174 ns/op	      27 B/op	       6 allocs/op
BenchmarkPaddingString-8   	 6750068	       177 ns/op	      28 B/op	       6 allocs/op
BenchmarkPaddingString-8   	 6726186	       193 ns/op	      28 B/op	       6 allocs/op
BenchmarkPaddingString-8   	 6153933	       192 ns/op	      28 B/op	       6 allocs/op
```

benchstat:
```hs
name             old time/op    new time/op    delta
PaddingString-8     365ns ± 5%     178ns ± 9%  -51.40%  (p=0.000 n=10+10)

name             old alloc/op   new alloc/op   delta
PaddingString-8      431B ± 0%       28B ± 2%  -93.62%  (p=0.000 n=7+10)

name             old allocs/op  new allocs/op  delta
PaddingString-8      11.0 ± 0%       6.0 ± 0%  -45.45%  (p=0.000 n=10+10)
```

But yeah, MORE code again 😄 