### PR TITLE
Implement an ANSI-aware string truncation function

### DIFF
--- a/ansi/buffer.go
+++ b/ansi/buffer.go
@@ -33,6 +33,10 @@ func PrintableRuneWidth(s string) int {
 // Truncate truncates a given string at the given printable cell width, leaving
 // any ansi sequences intact.
 func Truncate(s string, w int, tail string) string {
+	if PrintableRuneWidth(s) <= w {
+		return s
+	}
+
 	var n int
 	var ansi bool
 	var acc strings.Builder

--- a/ansi/buffer.go
+++ b/ansi/buffer.go
@@ -32,7 +32,14 @@ func PrintableRuneWidth(s string) int {
 
 // Truncate truncates a given string at the given printable cell width, leaving
 // any ansi sequences intact.
-func Truncate(s string, w int, tail string) string {
+func Truncate(s string, w int) string {
+	return TruncateWithTail(s, w, "")
+}
+
+// TruncateWithTail truncates a given string at the given printable cell width,
+// leaving any ansi sequences intact. A tail is then added to the end of the
+// string.
+func TruncateWithTail(s string, w int, tail string) string {
 	if PrintableRuneWidth(s) <= w {
 		return s
 	}

--- a/ansi/buffer.go
+++ b/ansi/buffer.go
@@ -2,6 +2,7 @@ package ansi
 
 import (
 	"bytes"
+	"strings"
 
 	"github.com/mattn/go-runewidth"
 )
@@ -11,28 +12,56 @@ type Buffer struct {
 	bytes.Buffer
 }
 
-// PrintableRuneWidth returns the width of all printable runes in the buffer.
+// PrintableRuneWidth returns the cell width of all printable runes in the
+// buffer.
 func (w Buffer) PrintableRuneWidth() int {
 	return PrintableRuneWidth(w.String())
 }
 
+// PrintableRuneWidth returns the cell width of the given string.
 func PrintableRuneWidth(s string) int {
 	var n int
 	var ansi bool
 
 	for _, c := range s {
-		if c == '\x1B' {
-			// ANSI escape sequence
-			ansi = true
-		} else if ansi {
-			if (c >= 0x40 && c <= 0x5a) || (c >= 0x61 && c <= 0x7a) {
-				// ANSI sequence terminated
-				ansi = false
-			}
-		} else {
-			n += runewidth.RuneWidth(c)
-		}
+		accPrintableRuneWidth(c, &n, &ansi)
 	}
 
 	return n
+}
+
+// Truncate truncates a given string at the given printable cell width, leaving
+// any ansi sequences intact.
+func Truncate(s string, w int, tail string) string {
+	var n int
+	var ansi bool
+	var acc strings.Builder
+
+	for _, c := range s {
+		accPrintableRuneWidth(c, &n, &ansi)
+		if n > w {
+			break
+		}
+
+		_, _ = acc.WriteRune(c)
+	}
+
+	_, _ = acc.WriteString(tail)
+	return acc.String()
+}
+
+// Used to accumulate the printable rune width while tracking whether we're in
+// an ansi sequence.
+func accPrintableRuneWidth(c rune, n *int, ansi *bool) {
+	if c == '\x1B' {
+		// ANSI escape sequence
+		*ansi = true
+	} else if *ansi {
+		if (c >= 0x40 && c <= 0x5a) || (c >= 0x61 && c <= 0x7a) {
+			// ANSI sequence terminated
+			*ansi = false
+		}
+	} else {
+		*n += runewidth.RuneWidth(c)
+	}
 }

--- a/ansi/buffer.go
+++ b/ansi/buffer.go
@@ -2,7 +2,6 @@ package ansi
 
 import (
 	"bytes"
-	"strings"
 
 	"github.com/mattn/go-runewidth"
 )
@@ -44,25 +43,31 @@ func TruncateWithTail(s string, w int, tail string) string {
 		return s
 	}
 
-	var n int
-	var ansi bool
-	var acc strings.Builder
+	const ansiReset = "\x1B[0m"
 
-	for _, c := range s {
-		accPrintableRuneWidth(c, &n, &ansi)
+	if tail != "" {
+		tail += ansiReset
+	}
+
+	tw := PrintableRuneWidth(tail)
+	w -= tw
+	if w < 0 {
+		return tail
+	}
+
+	r := []rune(s)
+	ansi := false
+	n := 0
+	i := 0
+
+	for ; i < len(r); i++ {
+		accPrintableRuneWidth(r[i], &n, &ansi)
 		if n > w {
 			break
 		}
-
-		_, _ = acc.WriteRune(c)
 	}
 
-	if ansi {
-		// terminate any open ANSI sequences
-		_, _ = acc.WriteString("\x1B[0m")
-	}
-	_, _ = acc.WriteString(tail)
-	return acc.String()
+	return string(r[0:i]) + ansiReset + tail
 }
 
 // Used to accumulate the printable rune width while tracking whether we're in

--- a/ansi/buffer.go
+++ b/ansi/buffer.go
@@ -30,13 +30,13 @@ func PrintableRuneWidth(s string) int {
 	return n
 }
 
-// Truncate truncates a given string at the given printable cell width, leaving
-// any ansi sequences intact.
+// Truncate truncates a string at the given printable cell width, leaving any
+// ansi sequences intact.
 func Truncate(s string, w int) string {
 	return TruncateWithTail(s, w, "")
 }
 
-// TruncateWithTail truncates a given string at the given printable cell width,
+// TruncateWithTail truncates a string at the given printable cell width,
 // leaving any ansi sequences intact. A tail is then added to the end of the
 // string.
 func TruncateWithTail(s string, w int, tail string) string {

--- a/ansi/buffer.go
+++ b/ansi/buffer.go
@@ -50,6 +50,7 @@ func Truncate(s string, w int, tail string) string {
 		_, _ = acc.WriteRune(c)
 	}
 
+	_, _ = acc.WriteString("\x1B[0m") // terminate any open ANSI sequences
 	_, _ = acc.WriteString(tail)
 	return acc.String()
 }

--- a/ansi/buffer.go
+++ b/ansi/buffer.go
@@ -50,7 +50,10 @@ func Truncate(s string, w int, tail string) string {
 		_, _ = acc.WriteRune(c)
 	}
 
-	_, _ = acc.WriteString("\x1B[0m") // terminate any open ANSI sequences
+	if ansi {
+		// terminate any open ANSI sequences
+		_, _ = acc.WriteString("\x1B[0m")
+	}
 	_, _ = acc.WriteString(tail)
 	return acc.String()
 }

--- a/ansi/buffer_test.go
+++ b/ansi/buffer_test.go
@@ -66,8 +66,7 @@ func Test_Truncate(t *testing.T) {
 		},
 	}
 
-	i := 0
-	for _, tt := range tests {
+	for i, tt := range tests {
 		t.Run(fmt.Sprintf("truncate-%d", i), func(t *testing.T) {
 			t.Parallel()
 			res := Truncate(tt.in, tt.width)
@@ -78,7 +77,6 @@ func Test_Truncate(t *testing.T) {
 				t.Fatalf("expected '%s' got '%s'\x1B[0m", tt.out, res)
 			}
 		})
-		i++
 	}
 }
 

--- a/ansi/buffer_test.go
+++ b/ansi/buffer_test.go
@@ -33,7 +33,7 @@ func Benchmark_PrintableRuneWidth(b *testing.B) {
 func Test_Truncate(t *testing.T) {
 	t.Parallel()
 
-	var s string = "\x1B[38;2;249;38;114m你好"
+	s := "\x1B[38;2;249;38;114m你\x1B[7m好\x1B[0m"
 
 	if n := PrintableRuneWidth(Truncate(s, 2, "")); n != 2 {
 		t.Fatalf("width should be 2, got %d", n)
@@ -42,7 +42,7 @@ func Test_Truncate(t *testing.T) {
 
 // go test -bench=Benchmark_Truncate -benchmem -count=4
 func Benchmark_Truncate(b *testing.B) {
-	s := "\x1B[38;2;249;38;114m你好"
+	s := "\x1B[38;2;249;38;114m你\x1B[7m好\x1B[0m"
 
 	b.RunParallel(func(pb *testing.PB) {
 		b.ReportAllocs()

--- a/ansi/buffer_test.go
+++ b/ansi/buffer_test.go
@@ -29,3 +29,26 @@ func Benchmark_PrintableRuneWidth(b *testing.B) {
 		}
 	})
 }
+
+func Test_Truncate(t *testing.T) {
+	t.Parallel()
+
+	var s string = "\x1B[38;2;249;38;114m你好"
+
+	if n := PrintableRuneWidth(Truncate(s, 2, "")); n != 2 {
+		t.Fatalf("width should be 2, got %d", n)
+	}
+}
+
+// go test -bench=Benchmark_Truncate -benchmem -count=4
+func Benchmark_Truncate(b *testing.B) {
+	s := "\x1B[38;2;249;38;114m你好"
+
+	b.RunParallel(func(pb *testing.PB) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for pb.Next() {
+			Truncate(s, 2, "")
+		}
+	})
+}

--- a/ansi/buffer_test.go
+++ b/ansi/buffer_test.go
@@ -33,10 +33,15 @@ func Benchmark_PrintableRuneWidth(b *testing.B) {
 func Test_Truncate(t *testing.T) {
 	t.Parallel()
 
-	s := "\x1B[38;2;249;38;114m你\x1B[7m好\x1B[0m"
+	in := "\x1B[38;2;249;38;114m你\x1B[7m好\x1B[0m"
+	out := "\x1B[38;2;249;38;114m你\x1B[7m\x1B[0m"
+	res := Truncate(in, 2)
 
-	if n := PrintableRuneWidth(Truncate(s, 2, "")); n != 2 {
+	if n := PrintableRuneWidth(res); n != 2 {
 		t.Fatalf("width should be 2, got %d", n)
+	}
+	if res != out {
+		t.Fatalf("expected %s got %s\x1B[0m", out, res)
 	}
 }
 
@@ -48,7 +53,7 @@ func Benchmark_Truncate(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for pb.Next() {
-			Truncate(s, 2, "")
+			Truncate(s, 2)
 		}
 	})
 }


### PR DESCRIPTION
Tests are also included. Also, I haven't implemented this on `Buffer` yet.

I abstracted out the code for detecting ANSI start and end sequences for sake of reuse, which impacts performance very slightly (thanks @kiyonlin for the benchmarking tests). We could instead manually inline that function if we wanted for a slight performance boost.

This closes #21.