### PR TITLE
More truncate tests + bump go-runewidth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/muesli/reflow
 
 go 1.13
 
-require github.com/mattn/go-runewidth v0.0.9
+require (
+	github.com/mattn/go-runewidth v0.0.10
+	github.com/rivo/uniseg v0.2.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
-github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
-github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
+github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
+github.com/rivo/uniseg v0.1.0 h1:+2KBaVoUmb9XzDsrx/Ct0W/EYOSFf/nWTauy++DprtY=
+github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/truncate/truncate_test.go
+++ b/truncate/truncate_test.go
@@ -52,12 +52,47 @@ func TestTruncate(t *testing.T) {
 			"foo",
 			"...",
 		},
-		// ANSI sequence codes:
+		// Spaces only:
+		{
+			2,
+			"…",
+			"    ",
+			" …",
+		},
+		// Double-width runes:
+		{
+			2,
+			"",
+			"你好",
+			"你",
+		},
+		// Double-width rune is dropped if it is too wide:
+		{
+			1,
+			"",
+			"你",
+			"",
+		},
+		// ANSI sequence codes and double-width characters:
 		{
 			3,
 			"",
 			"\x1B[38;2;249;38;114m你好\x1B[0m",
 			"\x1B[38;2;249;38;114m你\x1B[0m",
+		},
+		// Reset styling sequence is added after truncate:
+		{
+			1,
+			"",
+			"\x1B[7m--",
+			"\x1B[7m-\x1B[0m",
+		},
+		// Reset styling sequence not added if operation is a noop:
+		{
+			2,
+			"",
+			"\x1B[7m--",
+			"\x1B[7m--",
 		},
 	}
 


### PR DESCRIPTION
This PR adds additional tests to verify some of the `truncate` package's idiosyncrasies as well as verify some of the behavior we're inheriting from `go-runewidth`.

This PR also bumps `go-runewidth` to the current version which contains improvements to width detection (see: mattn/go-runewidth#29).