### PR TITLE
Use ansi package to find ANSI marker/terminators in truncate package

### DIFF
--- a/truncate/truncate.go
+++ b/truncate/truncate.go
@@ -80,11 +80,11 @@ func (w *Writer) Write(b []byte) (int, error) {
 	var curWidth uint
 
 	for _, c := range string(b) {
-		if c == '\x1B' {
+		if c == ansi.Marker {
 			// ANSI escape sequence
 			w.ansi = true
 		} else if w.ansi {
-			if (c >= 0x41 && c <= 0x5a) || (c >= 0x61 && c <= 0x7a) {
+			if ansi.IsTerminator(c) {
 				// ANSI sequence terminated
 				w.ansi = false
 			}


### PR DESCRIPTION
This PR updates the truncate package to use the ansi package to detect the presence of ANSI sequences. Currently the truncate package re-implements the detection.