### PR TITLE
Print tail before resetting ANSI when truncating

### DIFF
--- a/truncate/truncate.go
+++ b/truncate/truncate.go
@@ -93,10 +93,11 @@ func (w *Writer) Write(b []byte) (int, error) {
 		}
 
 		if curWidth > w.width {
+			n, err := w.buf.WriteString(w.tail)
 			if w.ansiWriter.LastSequence() != "" {
 				w.ansiWriter.ResetAnsi()
 			}
-			return w.buf.WriteString(w.tail)
+			return n, err
 		}
 
 		_, err := w.ansiWriter.Write([]byte(string(c)))

--- a/truncate/truncate_test.go
+++ b/truncate/truncate_test.go
@@ -94,6 +94,13 @@ func TestTruncate(t *testing.T) {
 			"\x1B[7m--",
 			"\x1B[7m--",
 		},
+		// Tail is printed before reset sequence:
+		{
+			3,
+			"…",
+			"\x1B[38;5;219mHiya!",
+			"\x1B[38;5;219mHi…\x1B[0m",
+		},
 	}
 
 	for i, tc := range tt {


### PR DESCRIPTION
This PR adjusts `truncate.BytesWithTail` and `truncate.StringWithTail` so that the tail is printed before the ANSI reset sequence. A test is included to verify the change.

```go
ansi.StringWithTail("\x1B[38;5;219mHiya!", 3, "…")
// before: "\x1B[38;5;219mHi\x1B[0m…"
// after: "\x1B[38;5;219mHi…\x1B[0m"
```

Closes #35.