### PR TITLE
Fix indent example output in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,10 @@ s := indent.String("Hello World!", 4)
 fmt.Println(s)
 ```
 
-Result: `    Hello World!`
+Result:
+```
+    Hello World!
+```
 
 There is also an indenting Writer, which is compatible with the `io.Writer`
 interface:


### PR DESCRIPTION
Currently the string is not indented correctly when README.md is
rendered - on GitHub at least.