### PR TITLE
wrap: use `(*Wrap).Bytes` in `Bytes`

### DIFF
--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -51,7 +51,7 @@ func Bytes(b []byte, limit int) []byte {
 	f := NewWriter(limit)
 	_, _ = f.Write(b)
 
-	return f.buf.Bytes()
+	return f.Bytes()
 }
 
 func (w *Wrap) addNewLine() {

--- a/wrap/wrap_test.go
+++ b/wrap/wrap_test.go
@@ -1,6 +1,7 @@
 package wrap
 
 import (
+	"bytes"
 	"testing"
 )
 
@@ -132,9 +133,21 @@ func TestWrap(t *testing.T) {
 }
 
 func TestWrapString(t *testing.T) {
+	t.Parallel()
+
 	actual := String("foo bar", 3)
 	expected := "foo\nbar"
 	if actual != expected {
+		t.Errorf("expected:\n\n`%s`\n\nActual Output:\n\n`%s`", expected, actual)
+	}
+}
+
+func TestWrapBytes(t *testing.T) {
+	t.Parallel()
+
+	actual := Bytes([]byte("foo bar"), 3)
+	expected := []byte("foo\nbar")
+	if !bytes.Equal(actual, expected) {
 		t.Errorf("expected:\n\n`%s`\n\nActual Output:\n\n`%s`", expected, actual)
 	}
 }


### PR DESCRIPTION
Similar to other packages, let the `Bytes` func call the writer's `Bytes`
method instead of directly calling `(*Wrap).buf.Bytes()`. Also add a test
for `Bytes` to achieve 100% test coverage.