### PR TITLE
Count breakpoint for running line length when word wrapping

### DIFF
--- a/wordwrap/wordwrap.go
+++ b/wordwrap/wordwrap.go
@@ -78,6 +78,11 @@ func (w *WordWrap) addNewLine() {
 	w.space.Reset()
 }
 
+func (w *WordWrap) addBreakpoint(c rune) {
+	n, _ := w.buf.WriteRune(c)
+	w.lineLen += n
+}
+
 func inGroup(a []rune, c rune) bool {
 	for _, v := range a {
 		if v == c {
@@ -132,7 +137,7 @@ func (w *WordWrap) Write(b []byte) (int, error) {
 			// valid breakpoint
 			w.addSpace()
 			w.addWord()
-			_, _ = w.buf.WriteRune(c)
+			w.addBreakpoint(c)
 		} else {
 			// any other character
 			_, _ = w.word.WriteRune(c)

--- a/wordwrap/wordwrap_test.go
+++ b/wordwrap/wordwrap_test.go
@@ -47,6 +47,13 @@ func TestWordWrap(t *testing.T) {
 			4,
 			true,
 		},
+		// A breakpoint counts towards when to wrap:
+		{
+			"foo-a-bar",
+			"foo-\na-\nbar",
+			4,
+			true,
+		},
 		// Space buffer needs to be emptied before breakpoints:
 		{
 			"foo --bar",


### PR DESCRIPTION
Breakpoint runes now contribute to the running line length that helps determine when to break. If not counted, a line can exceed the desired width when a word is exactly one byte less than the width, for a single byte separator.