### PR TITLE
Avoid truncation for inputs close to limit

### DIFF
--- a/truncate/truncate_test.go
+++ b/truncate/truncate_test.go
@@ -38,10 +38,24 @@ func TestTruncate(t *testing.T) {
 			"foobar",
 			"foo.",
 		},
-		// Same width:
+		// Same width with no tail:
 		{
 			3,
 			"",
+			"foo",
+			"foo",
+		},
+		// Same width with tail:
+		{
+			3,
+			".",
+			"foo",
+			"foo",
+		},
+		// Pass through when in + tail longer than width, but in shorter:
+		{
+			4,
+			"...",
 			"foo",
 			"foo",
 		},
@@ -65,6 +79,13 @@ func TestTruncate(t *testing.T) {
 			"",
 			"你好",
 			"你",
+		},
+		// Double-width runes with tail:
+		{
+			4,
+			".",
+			"你好",
+			"你好",
 		},
 		// Double-width rune is dropped if it is too wide:
 		{


### PR DESCRIPTION
Previous truncation code always truncated and added a tail once the processed input width exceeded the limit minus the tail width. For example, the input "foobar" truncated to width 6 with a tail "." would come out as "fooba.".

Now, when the rune scanning loop passes into the danger zone where truncation might be required, but before the truncation limit is breached, it buffers runes instead of writing them out. If the truncation limit is exceeded, then the tail is written as usual. If it ends up not exceeded, then the buffered runes are written out, avoiding unnecessary truncation.