### PR TITLE
Enhance parser to understand more than just CSI sequences

### DIFF
--- a/ansi/buffer.go
+++ b/ansi/buffer.go
@@ -49,7 +49,7 @@ func PrintableRuneWidth(s string) int {
 				state = text
 			}
 		case stTerminated:
-			if s[i] == '\a' || (i > 0 && s[i] == '\\' && s[i-1] == '\033') {
+			if s[i] == '\a' || (i > 0 && s[i] == '\\' && s[i-1] == 0x1B) {
 				state = text
 			}
 		// case terminology:
@@ -57,7 +57,7 @@ func PrintableRuneWidth(s string) int {
 		//         state = text
 		//     }
 		case text:
-			if i > 0 && s[i-1] == '\033' {
+			if i > 0 && s[i-1] == 0x1B {
 				switch {
 				// nF escape sequences [0x20—0x2F]+[0x30-0x7E]
 				case s[i] >= 0x20 && s[i] <= 0x2F:

--- a/ansi/buffer.go
+++ b/ansi/buffer.go
@@ -34,57 +34,56 @@ func PrintableRuneWidth(s string) int {
 	var cpIdx int = -1 // index of first code point byte
 	// range over bytes not runes
 	for i := 0; i < len(s); i++ {
-		b := s[i]
 		switch state {
 		case nF: // [0x20—0x2F]+[0x30-0x7E]
 			switch {
-			case b >= 0x20 && b <= 0x2F:
-			case i > 0 && s[i-1] >= 0x20 && s[i-1] <= 0x2F && b >= 0x30 && b <= 0x7E:
+			case s[i] >= 0x20 && s[i] <= 0x2F:
+			case i > 0 && s[i-1] >= 0x20 && s[i-1] <= 0x2F && s[i] >= 0x30 && s[i] <= 0x7E:
 				state = text
 			default:
 				// fail
 				state = text
 			}
 		case csi: // [0x40-0x7E]
-			if b >= 0x40 && b <= 0x7E {
+			if s[i] >= 0x40 && s[i] <= 0x7E {
 				state = text
 			}
 		case stTerminated:
-			if b == '\a' || (i > 0 && b == '\\' && s[i-1] == '\033') {
+			if s[i] == '\a' || (i > 0 && s[i] == '\\' && s[i-1] == '\033') {
 				state = text
 			}
 		// case terminology:
-		//     if b == '\x00' {
+		//     if s[i] == '\x00' {
 		//         state = text
 		//     }
 		case text:
 			if i > 0 && s[i-1] == '\033' {
 				switch {
 				// nF escape sequences [0x20—0x2F]+[0x30-0x7E]
-				case b >= 0x20 && b <= 0x2F:
+				case s[i] >= 0x20 && s[i] <= 0x2F:
 					state = nF
 
 				// Fp escape sequences [0x30—0x3F]
-				case b >= 0x30 && b <= 0x3F:
+				case s[i] >= 0x30 && s[i] <= 0x3F:
 
 				// Fe escape sequences [0x40-0x5F]
 				// CSI - terminated by [0x40-0x7E]
-				case b == '[':
+				case s[i] == '[':
 					state = csi
 				// DCS, OSC, SOS, PM, APC - ST terminated
-				case b == 'P' || b == ']' || b == 'X' || b == '^' || b == '_':
+				case s[i] == 'P' || s[i] == ']' || s[i] == 'X' || s[i] == '^' || s[i] == '_':
 					state = stTerminated
-				case b >= 0x40 && b <= 0x5F:
+				case s[i] >= 0x40 && s[i] <= 0x5F:
 
 				// Terminology  \x00 terminated - conflicts with Fs escape sequences
 				// https://github.com/borisfaure/terminology/tree/master#extended-escapes-for-terminology-only
-				// case recognizeTerminologyEscSequences && r == '}':
+				// case recognizeTerminologyEscSequences && s[i] == '}':
 				//     state = terminology
 				// Fs escape sequences [0x60—0x7E]
-				case b >= 0x60 && b <= 0x7E:
+				case s[i] >= 0x60 && s[i] <= 0x7E:
 				}
 			} else {
-				if utf8.RuneStart(b) {
+				if utf8.RuneStart(s[i]) {
 					cpIdx = i
 				}
 				// cpBytes := unsafe.Slice(unsafe.StringData(s[cpIdx:i+1]), i-cpIdx+1) // go 1.20

--- a/ansi/buffer.go
+++ b/ansi/buffer.go
@@ -30,7 +30,7 @@ func PrintableRuneWidth(s string) int {
 	)
 	// var recognizeTerminologyEscSequences bool = false
 	var state int8 = text
-	var ret int
+	var n int
 	var cpIdx int = -1 // index of first code point byte
 	// range over bytes not runes
 	for i := 0; i < len(s); i++ {
@@ -91,11 +91,12 @@ func PrintableRuneWidth(s string) int {
 				cpBytes := []byte(s[cpIdx : i+1])
 				if utf8.FullRune(cpBytes) {
 					if rn, _ := utf8.DecodeRune(cpBytes); rn != utf8.RuneError {
-						ret += runewidth.RuneWidth(rn)
+						n += runewidth.RuneWidth(rn)
 					}
 				}
 			}
 		}
 	}
-	return ret
+
+	return n
 }

--- a/ansi/buffer.go
+++ b/ansi/buffer.go
@@ -2,6 +2,7 @@ package ansi
 
 import (
 	"bytes"
+	"unicode/utf8"
 
 	"github.com/mattn/go-runewidth"
 )
@@ -19,22 +20,82 @@ func (w Buffer) PrintableRuneWidth() int {
 
 // PrintableRuneWidth returns the cell width of the given string.
 func PrintableRuneWidth(s string) int {
-	var n int
-	var ansi bool
-
-	for _, c := range s {
-		if c == Marker {
-			// ANSI escape sequence
-			ansi = true
-		} else if ansi {
-			if IsTerminator(c) {
-				// ANSI sequence terminated
-				ansi = false
+	// https://en.wikipedia.org/wiki/ANSI_escape_code
+	const (
+		text int8 = iota + 1
+		nF
+		csi
+		stTerminated
+		// terminology
+	)
+	// var recognizeTerminologyEscSequences bool = false
+	var state int8 = text
+	var ret int
+	var cpIdx int = -1 // index of first code point byte
+	// range over bytes not runes
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		switch state {
+		case nF: // [0x20—0x2F]+[0x30-0x7E]
+			switch {
+			case b >= 0x20 && b <= 0x2F:
+			case i > 0 && s[i-1] >= 0x20 && s[i-1] <= 0x2F && b >= 0x30 && b <= 0x7E:
+				state = text
+			default:
+				// fail
+				state = text
 			}
-		} else {
-			n += runewidth.RuneWidth(c)
+		case csi: // [0x40-0x7E]
+			if b >= 0x40 && b <= 0x7E {
+				state = text
+			}
+		case stTerminated:
+			if b == '\a' || (i > 0 && b == '\\' && s[i-1] == '\033') {
+				state = text
+			}
+		// case terminology:
+		//     if b == '\x00' {
+		//         state = text
+		//     }
+		case text:
+			if i > 0 && s[i-1] == '\033' {
+				switch {
+				// nF escape sequences [0x20—0x2F]+[0x30-0x7E]
+				case b >= 0x20 && b <= 0x2F:
+					state = nF
+
+				// Fp escape sequences [0x30—0x3F]
+				case b >= 0x30 && b <= 0x3F:
+
+				// Fe escape sequences [0x40-0x5F]
+				// CSI - terminated by [0x40-0x7E]
+				case b == '[':
+					state = csi
+				// DCS, OSC, SOS, PM, APC - ST terminated
+				case b == 'P' || b == ']' || b == 'X' || b == '^' || b == '_':
+					state = stTerminated
+				case b >= 0x40 && b <= 0x5F:
+
+				// Terminology  \x00 terminated - conflicts with Fs escape sequences
+				// https://github.com/borisfaure/terminology/tree/master#extended-escapes-for-terminology-only
+				// case recognizeTerminologyEscSequences && r == '}':
+				//     state = terminology
+				// Fs escape sequences [0x60—0x7E]
+				case b >= 0x60 && b <= 0x7E:
+				}
+			} else {
+				if utf8.RuneStart(b) {
+					cpIdx = i
+				}
+				// cpBytes := unsafe.Slice(unsafe.StringData(s[cpIdx:i+1]), i-cpIdx+1) // go 1.20
+				cpBytes := []byte(s[cpIdx : i+1])
+				if utf8.FullRune(cpBytes) {
+					if rn, _ := utf8.DecodeRune(cpBytes); rn != utf8.RuneError {
+						ret += runewidth.RuneWidth(rn)
+					}
+				}
+			}
 		}
 	}
-
-	return n
+	return ret
 }

--- a/ansi/buffer_test.go
+++ b/ansi/buffer_test.go
@@ -8,12 +8,27 @@ import (
 func TestBuffer_PrintableRuneWidth(t *testing.T) {
 	t.Parallel()
 
-	var bb bytes.Buffer
-	bb.WriteString("\x1B[38;2;249;38;114mfoo")
-	b := Buffer{bb}
+	tests := []struct {
+		name string
+		s    string
+		len  int
+	}{
+		{"CSI", "\x1B[38;2;249;38;114mfoo", 3},
+		// sixel example from wikipedia
+		{"DCS", "\x1BPq#0;2;0;0;0#1;2;100;100;0#2;2;0;100;0#1~~@@vv@@~~@@~~$#2??}}GG}}??}}??-#1!14@\x1B\\foo", 3},
+		{"wide_chars", "Hello, 世界", 11},
+	}
 
-	if n := b.PrintableRuneWidth(); n != 3 {
-		t.Fatalf("width should be 3, got %d", n)
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+			var bb bytes.Buffer
+			bb.WriteString(tst.s)
+			b := Buffer{bb}
+
+			if n := b.PrintableRuneWidth(); n != tst.len {
+				t.Fatalf("width should be %d, got %d", tst.len, n)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Currently [PrintableRuneWidth](https://github.com/muesli/reflow/blob/eee88dd/ansi/buffer.go#L20)() only looks out for CSI sequences in the ANSI standard. This PR adds support for [common ST-terminated](https://en.wikipedia.org/wiki/ANSI_escape_code#Fe_Escape_sequences) (ST = STRING TERMINATOR | "ESC \" or "\a") sequences. Examples are OSC-sequences used by the [**sixel**](https://en.wikipedia.org/wiki/Sixel),[iTerm2](https://iterm2.com/documentation-images.html), [DomTerm](https://domterm.org/Wire-byte-protocol.html#Miscellaneous-sequences) graphics format, APC-sequences (used for [kitty](https://sw.kovidgoyal.net/kitty/graphics-protocol/) graphics). This code is taken from my [termimg](https://github.com/srlehn/termimg/blob/1f9c82b/internal/parser/parse.go#L76) library and modified slightly.


Fixes #64
