### PR TITLE
fix wordwrap of hyphens at limit

### DIFF
--- a/wordwrap/wordwrap.go
+++ b/wordwrap/wordwrap.go
@@ -130,9 +130,13 @@ func (w *WordWrap) Write(b []byte) (int, error) {
 			_, _ = w.space.WriteRune(c)
 		} else if inGroup(w.Breakpoints, c) {
 			// valid breakpoint
-			w.addSpace()
-			w.addWord()
-			_, _ = w.buf.WriteRune(c)
+			_, _ = w.word.WriteRune(c)
+
+			// if we're still within the limit, we can go ahead and write the
+			// word-thus-far (as though it were a complete word itself)
+			if w.lineLen+w.space.Len()+w.word.PrintableRuneWidth() <= w.Limit {
+				w.addWord()
+			}
 		} else {
 			// any other character
 			_, _ = w.word.WriteRune(c)

--- a/wordwrap/wordwrap.go
+++ b/wordwrap/wordwrap.go
@@ -128,15 +128,6 @@ func (w *WordWrap) Write(b []byte) (int, error) {
 			// end of current word
 			w.addWord()
 			_, _ = w.space.WriteRune(c)
-		} else if inGroup(w.Breakpoints, c) {
-			// valid breakpoint
-			_, _ = w.word.WriteRune(c)
-
-			// if we're still within the limit, we can go ahead and write the
-			// word-thus-far (as though it were a complete word itself)
-			if w.lineLen+w.space.Len()+w.word.PrintableRuneWidth() <= w.Limit {
-				w.addWord()
-			}
 		} else {
 			// any other character
 			_, _ = w.word.WriteRune(c)
@@ -146,6 +137,12 @@ func (w *WordWrap) Write(b []byte) (int, error) {
 			if w.lineLen+w.space.Len()+w.word.PrintableRuneWidth() > w.Limit &&
 				w.word.PrintableRuneWidth() < w.Limit {
 				w.addNewLine()
+			}
+
+			// if we just saw a breakpoint, it's like seeing a space; we
+			// immediately flush the word-in-progress to the buffer
+			if inGroup(w.Breakpoints, c) {
+				w.addWord()
 			}
 		}
 	}

--- a/wordwrap/wordwrap_test.go
+++ b/wordwrap/wordwrap_test.go
@@ -47,6 +47,13 @@ func TestWordWrap(t *testing.T) {
 			4,
 			true,
 		},
+		// A hyphen should not bypass the limit:
+		{
+			"foo foo-foobar",
+			"foo\nfoo-foobar",
+			7,
+			true,
+		},
 		// Space buffer needs to be emptied before breakpoints:
 		{
 			"foo --bar",

--- a/wordwrap/wordwrap_test.go
+++ b/wordwrap/wordwrap_test.go
@@ -61,6 +61,14 @@ func TestWordWrap(t *testing.T) {
 			3,
 			true,
 		},
+		// hyphenated portions of words don't have inner breaks, but do break at
+		// the hyphen
+		{
+			"foobar-foobar-foobar",
+			"foobar-\nfoobar-\nfoobar",
+			3,
+			true,
+		},
 		// Space buffer needs to be emptied before breakpoints:
 		{
 			"foo --bar",

--- a/wordwrap/wordwrap_test.go
+++ b/wordwrap/wordwrap_test.go
@@ -50,8 +50,15 @@ func TestWordWrap(t *testing.T) {
 		// A hyphen should not bypass the limit:
 		{
 			"foo foo-foobar",
-			"foo\nfoo-foobar",
+			"foo\nfoo-\nfoobar", // *not* "foo foo-\nfoobar"
 			7,
+			true,
+		},
+		// A run of hyphens breaks at the limit
+		{
+			"--------",
+			"---\n---\n--",
+			3,
 			true,
 		},
 		// Space buffer needs to be emptied before breakpoints:


### PR DESCRIPTION
If the word-thus-far is exactly at the limit and `wordwrap.Write()` sees a hyphen, it writes the word to the buffer and then writes hyphen, exceeding the limit. This change fixes that behavior by instead adding the hyphen to the word as a normal character, performing the existing "is the word-in-progress too long" check to add a newline, and *then* writing the word-in-progress (without any length check). 

It is still possible to see a hyphen beyond the limit, but that's a specific case of "don't break a word", where the hyphen is considered a part of the test to its left.

Fixes #66