### PR TITLE
Replace go-runewidth with uniseg

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [~1.11, ^1]
+        go-version: [~1.18, ^1]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:

--- a/ansi/buffer.go
+++ b/ansi/buffer.go
@@ -3,7 +3,7 @@ package ansi
 import (
 	"bytes"
 
-	"github.com/mattn/go-runewidth"
+	"github.com/rivo/uniseg"
 )
 
 // Buffer is a buffer aware of ANSI escape sequences.
@@ -19,22 +19,22 @@ func (w Buffer) PrintableRuneWidth() int {
 
 // PrintableRuneWidth returns the cell width of the given string.
 func PrintableRuneWidth(s string) int {
-	var n int
+	n := make([]rune, 0, len(s))
 	var ansi bool
 
 	for _, c := range s {
-		if c == Marker {
+		switch {
+		case c == Marker:
 			// ANSI escape sequence
 			ansi = true
-		} else if ansi {
-			if IsTerminator(c) {
-				// ANSI sequence terminated
-				ansi = false
-			}
-		} else {
-			n += runewidth.RuneWidth(c)
+		case ansi && IsTerminator(c):
+			// ANSI sequence terminated
+			ansi = false
+		case ansi:
+		default:
+			n = append(n, c)
 		}
 	}
 
-	return n
+	return uniseg.StringWidth(string(n))
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/muesli/reflow
 
-go 1.13
+go 1.18
 
-require github.com/mattn/go-runewidth v0.0.14
+require github.com/rivo/uniseg v0.4.6

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
-github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
-github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rivo/uniseg v0.4.6 h1:Sovz9sDSwbOz9tgUy8JpT+KgCkPYJEN/oYzlJiYTNLg=
+github.com/rivo/uniseg v0.4.6/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/padding/padding.go
+++ b/padding/padding.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"strings"
 
-	"github.com/mattn/go-runewidth"
 	"github.com/muesli/reflow/ansi"
+	"github.com/rivo/uniseg"
 )
 
 type PaddingFunc func(w io.Writer)
@@ -71,7 +71,7 @@ func (w *Writer) Write(b []byte) (int, error) {
 				w.ansi = false
 			}
 		} else {
-			w.lineLen += runewidth.StringWidth(string(c))
+			w.lineLen += uniseg.StringWidth(string(c))
 
 			if c == '\n' {
 				// end of current line

--- a/truncate/truncate_test.go
+++ b/truncate/truncate_test.go
@@ -170,7 +170,7 @@ func TestWriter_Error(t *testing.T) {
 
 	f := &Writer{
 		width:      2,
-		ansiWriter: &ansi.Writer{Forward: fakeWriter{}},
+		ansiWriter: ansi.Writer{Forward: fakeWriter{}},
 	}
 
 	if _, err := f.Write([]byte("foo")); err != fakeErr {


### PR DESCRIPTION
Replace the use of `RuneWidth` and `StringWidth` from `mattn/go- runewidth` with equivalent functions from `rivo/uniseg`.

It is important to be aware that using `RuneWidth` will not be accurate as the width of a rune cannot be determined in isolation. This requires a shift to thinking about grapheme clusters instead.

Unfortunately due to the complexity of identifying grapheme clusters, there has been some signifcant performance regressions in two functions:

- PrintableRuneWidth: 10x slower
- TruncateString: 4x slower

Two other functions have had performance improvements:

- MarginString: 2x faster
- PaddingString: 2x faster

The documentation for `rivo/uniseg` mentions the use of `Step` and `StepString` performing "orders of magnitude faster" than using the `NewGraphemes` method. However, implementing these changes only resulted in a 10% performance increase.